### PR TITLE
Fixes ansible error: 'dict object' has no attribute 'Slave_IO_Running'

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -33,8 +33,8 @@
     mode: stopslave
   when: >
     slave|failed
-    or (slave.Slave_IO_Running == 'No')
-    or (slave.Slave_SQL_Running == 'No')
+    or (slave.Slave_IO_Running | default('No') == 'No')
+    or (slave.Slave_SQL_Running | default('No') == 'No')
 
 - debug: msg="{{ slave }}"
 
@@ -45,8 +45,8 @@
   register: master
   when: >
     slave|failed
-    or (slave.Slave_IO_Running == 'No')
-    or (slave.Slave_SQL_Running == 'No')
+    or (slave.Slave_IO_Running | default('No') == 'No')
+    or (slave.Slave_SQL_Running | default('No') == 'No')
 
 - debug: msg="{{ master }}"
 
@@ -61,13 +61,13 @@
   ignore_errors: true
   when: >
     slave|failed
-    or (slave.Slave_IO_Running == 'No')
-    or (slave.Slave_SQL_Running == 'No')
+    or (slave.Slave_IO_Running | default('No') == 'No')
+    or (slave.Slave_SQL_Running | default('No') == 'No')
 
 - name: Start replication
   mysql_replication:
     mode: startslave
   when: >
     slave|failed
-    or (slave.Slave_IO_Running == 'No')
-    or (slave.Slave_SQL_Running == 'No')
+    or (slave.Slave_IO_Running | default('No') == 'No')
+    or (slave.Slave_SQL_Running | default('No') == 'No')


### PR DESCRIPTION
On fresh install master-master replication following error prevents execution:
```
"msg": "The conditional check 'slave|failed or (slave.Slave_IO_Running == 'No') or (slave.Slave_SQL_Running == 'No')\n' failed. The error was: error while evaluating conditional (slave|failed or (slave.Slave_IO_Running == 'No') or (slave.Slave_SQL_Running == 'No')\n): 'dict object' has no attribute 'Slave_IO_Running'\n\nThe error appears to have been in '/home/redhat/Dropbox/stuff/ansible/eric_bechtel/roles/tschifftner.mariadb/tasks/replication.yml': line 31, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Start replication\n  ^ here\n"
```
This pull request fixes this problem.